### PR TITLE
Major refactoring

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,7 +11,8 @@
         "Parts"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/examples/0-counter-part.elm
+++ b/examples/0-counter-part.elm
@@ -1,7 +1,6 @@
 import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
-import Dict
 
 import Counter
 
@@ -26,7 +25,7 @@ type alias Model =
 
 init : (Model, Cmd Msg)
 init =
-  ( { counters = Dict.empty }
+  ( { counters = .empty Counter.all }
   , Cmd.none
   )
 

--- a/examples/0-counter-part.elm
+++ b/examples/0-counter-part.elm
@@ -1,10 +1,9 @@
 import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
-import Dict 
+import Dict
 
 import Counter
-import Parts exposing (Indexed)
 
 
 main : Program Never
@@ -21,13 +20,13 @@ main =
 
 
 type alias Model =
-  { counter : Indexed Counter.Model 
+  { counters : Counter.Counters
   }
 
 
 init : (Model, Cmd Msg)
 init =
-  ( { counter = Dict.empty }
+  ( { counters = Dict.empty }
   , Cmd.none
   )
 
@@ -37,7 +36,7 @@ init =
 
 type Msg
   = Reset
-  | CounterMsg (Parts.Msg Model)
+  | CounterMsg (Counter.Msg, Counter.ID)
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -47,7 +46,7 @@ update msg model =
       init
 
     CounterMsg msg' -> 
-      Parts.update CounterMsg msg' model
+      Counter.pass CounterMsg msg' model
 
 
 -- VIEW

--- a/examples/0-counter-part.elm
+++ b/examples/0-counter-part.elm
@@ -2,7 +2,7 @@ import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
 
-import Counter
+import Counters exposing (Counters)
 
 
 main : Program Never
@@ -19,13 +19,13 @@ main =
 
 
 type alias Model =
-  { counters : Counter.Counters
+  { counters : Counters
   }
 
 
 init : (Model, Cmd Msg)
 init =
-  ( { counters = .empty Counter.all }
+  ( { counters = .empty Counters.all }
   , Cmd.none
   )
 
@@ -35,7 +35,7 @@ init =
 
 type Msg
   = Reset
-  | CounterMsg (Counter.Msg, Counter.ID)
+  | CounterMsg (Counters.Msg, Counters.ID)
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -45,7 +45,7 @@ update msg model =
       init
 
     CounterMsg msg' -> 
-      Counter.pass CounterMsg msg' model
+      Counters.pass CounterMsg msg' model
 
 
 -- VIEW
@@ -55,6 +55,6 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ Counter.render CounterMsg [0] model
+    [ Counters.render CounterMsg [0] model
     , button [ onClick Reset ] [ text "RESET" ]
     ]

--- a/examples/0-counter-part.elm
+++ b/examples/0-counter-part.elm
@@ -46,7 +46,7 @@ update msg model =
     Reset ->
       init
 
-    ControlMsg msg' -> 
+    ControlMsg msg' ->
       Controls.pass ControlMsg msg' model
 
 
@@ -57,7 +57,7 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ Counters.render ControlMsg [0] model
+    [ Counters.render (ControlMsg << Controls.CounterMsg) [0] model.controls
     , button [ onClick Reset ] [ text "RESET" ]
-    , Help.render ControlMsg model
+    , Help.render (ControlMsg << Controls.HelpMsg) model.controls
     ]

--- a/examples/0-counter-part.elm
+++ b/examples/0-counter-part.elm
@@ -3,6 +3,8 @@ import Html.App as App
 import Html.Events exposing (onClick)
 
 import Counters exposing (Counters)
+import Help exposing (Help)
+import Controls exposing (Controls)
 
 
 main : Program Never
@@ -19,13 +21,13 @@ main =
 
 
 type alias Model =
-  { counters : Counters
+  { controls : Controls
   }
 
 
 init : (Model, Cmd Msg)
 init =
-  ( { counters = .empty Counters.all }
+  ( { controls = .empty Controls.instance }
   , Cmd.none
   )
 
@@ -35,7 +37,7 @@ init =
 
 type Msg
   = Reset
-  | CounterMsg (Counters.Msg, Counters.ID)
+  | ControlMsg Controls.Msg
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -44,8 +46,8 @@ update msg model =
     Reset ->
       init
 
-    CounterMsg msg' -> 
-      Counters.pass CounterMsg msg' model
+    ControlMsg msg' -> 
+      Controls.pass ControlMsg msg' model
 
 
 -- VIEW
@@ -55,6 +57,7 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ Counters.render CounterMsg [0] model
+    [ Counters.render ControlMsg [0] model
     , button [ onClick Reset ] [ text "RESET" ]
+    , Help.render ControlMsg model
     ]

--- a/examples/0-counter.elm
+++ b/examples/0-counter.elm
@@ -1,5 +1,5 @@
 
-import Counter
+import Counters
 import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
@@ -20,13 +20,13 @@ main =
 
 
 type alias Model =
-  { counter : Counter.Model
+  { counter : Counters.Model
   }
 
 
 init : Int -> (Model, Cmd Msg)
 init x =
-  ( { counter = Counter.init x }
+  ( { counter = Counters.init x }
   , Cmd.none 
   )
 
@@ -37,7 +37,7 @@ init x =
 
 type Msg
   = Reset
-  | CounterMsg Counter.Msg
+  | CounterMsg Counters.Msg
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -49,7 +49,7 @@ update message model =
     CounterMsg msg ->
       let 
         (counter', cmd) = 
-          Counter.update msg model.counter 
+          Counters.update msg model.counter 
       in
         ( { model | counter = counter' }
         , Cmd.map CounterMsg cmd
@@ -62,6 +62,6 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ App.map CounterMsg (Counter.view model.counter)
+    [ App.map CounterMsg (Counters.view model.counter)
     , button [ onClick Reset ] [ text "RESET" ]
     ]

--- a/examples/0-counter.elm
+++ b/examples/0-counter.elm
@@ -1,5 +1,6 @@
 
 import Counters
+import Help
 import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
@@ -20,13 +21,16 @@ main =
 
 
 type alias Model =
-  { counter : Counters.Model
+  { counters : Counters.Model
+  , help : Help.Model
   }
 
 
 init : Int -> (Model, Cmd Msg)
 init x =
-  ( { counter = Counters.init x }
+  ( { counters = Counters.init x 
+    , help = Help.init
+    }
   , Cmd.none 
   )
 
@@ -38,6 +42,7 @@ init x =
 type Msg
   = Reset
   | CounterMsg Counters.Msg
+  | HelpMsg Help.Msg
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -49,10 +54,19 @@ update message model =
     CounterMsg msg ->
       let 
         (counter', cmd) = 
-          Counters.update msg model.counter 
+          Counters.update msg model.counters
       in
-        ( { model | counter = counter' }
+        ( { model | counters = counter' }
         , Cmd.map CounterMsg cmd
+        )
+    
+    HelpMsg msg ->
+      let 
+        (help', cmd) = 
+          Help.update msg model.help
+      in
+        ( { model | help = help' }
+        , Cmd.map HelpMsg cmd
         )
 
 -- VIEW
@@ -62,6 +76,7 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ App.map CounterMsg (Counters.view model.counter)
+    [ App.map CounterMsg (Counters.view model.counters)
     , button [ onClick Reset ] [ text "RESET" ]
+    , App.map HelpMsg (Help.view model.help)
     ]

--- a/examples/0-counter.elm
+++ b/examples/0-counter.elm
@@ -62,8 +62,6 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ Counter.view CounterMsg model.counter
-      -- We avoid Html.App.map because of
-      -- https://github.com/elm-lang/html/issues/16
+    [ App.map CounterMsg (Counter.view model.counter)
     , button [ onClick Reset ] [ text "RESET" ]
     ]

--- a/examples/1-counter-pair-part.elm
+++ b/examples/1-counter-pair-part.elm
@@ -1,7 +1,6 @@
 import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
-import Dict 
 
 import Counter
 
@@ -26,7 +25,7 @@ type alias Model =
 
 init : (Model, Cmd Msg)
 init =
-  ( { counters = Dict.empty }
+  ( { counters = .empty Counter.all }
   , Cmd.none
   )
 

--- a/examples/1-counter-pair-part.elm
+++ b/examples/1-counter-pair-part.elm
@@ -2,7 +2,7 @@ import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
 
-import Counter
+import Counters exposing (Counters)
 
 
 main : Program Never
@@ -19,13 +19,13 @@ main =
 
 
 type alias Model =
-  { counters : Counter.Counters
+  { counters : Counters
   }
 
 
 init : (Model, Cmd Msg)
 init =
-  ( { counters = .empty Counter.all }
+  ( { counters = .empty Counters.all }
   , Cmd.none
   )
 
@@ -35,7 +35,7 @@ init =
 
 type Msg
   = Reset
-  | CounterMsg (Counter.Msg, Counter.ID)
+  | CounterMsg (Counters.Msg, Counters.ID)
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -45,7 +45,7 @@ update msg model =
       init
 
     CounterMsg msg' -> 
-      Counter.pass CounterMsg msg' model
+      Counters.pass CounterMsg msg' model
 
 
 -- VIEW
@@ -55,7 +55,7 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ Counter.render CounterMsg [0] model
-    , Counter.render CounterMsg [1] model
+    [ Counters.render CounterMsg [0] model
+    , Counters.render CounterMsg [1] model
     , button [ onClick Reset ] [ text "RESET" ]
     ]

--- a/examples/1-counter-pair-part.elm
+++ b/examples/1-counter-pair-part.elm
@@ -4,7 +4,6 @@ import Html.Events exposing (onClick)
 import Dict 
 
 import Counter
-import Parts exposing (Indexed)
 
 
 main : Program Never
@@ -21,13 +20,13 @@ main =
 
 
 type alias Model =
-  { counter : Indexed Counter.Model 
+  { counters : Counter.Counters
   }
 
 
 init : (Model, Cmd Msg)
 init =
-  ( { counter = Dict.empty }
+  ( { counters = Dict.empty }
   , Cmd.none
   )
 
@@ -37,7 +36,7 @@ init =
 
 type Msg
   = Reset
-  | CounterMsg (Parts.Msg Model)
+  | CounterMsg (Counter.Msg, Counter.ID)
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -47,7 +46,7 @@ update msg model =
       init
 
     CounterMsg msg' -> 
-      Parts.update CounterMsg msg' model
+      Counter.pass CounterMsg msg' model
 
 
 -- VIEW

--- a/examples/1-counter-pair.elm
+++ b/examples/1-counter-pair.elm
@@ -1,5 +1,5 @@
 
-import Counter
+import Counters
 import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
@@ -20,15 +20,15 @@ main =
 
 
 type alias Model =
-  { topCounter : Counter.Model
-  , bottomCounter : Counter.Model
+  { topCounter : Counters.Model
+  , bottomCounter : Counters.Model
   }
 
 
 init : Int -> Int -> (Model, Cmd Msg)
 init top bottom =
-  ( { topCounter = Counter.init top
-    , bottomCounter = Counter.init bottom
+  ( { topCounter = Counters.init top
+    , bottomCounter = Counters.init bottom
     }
   , Cmd.none 
   )
@@ -40,8 +40,8 @@ init top bottom =
 
 type Msg
   = Reset
-  | Top Counter.Msg
-  | Bottom Counter.Msg
+  | Top Counters.Msg
+  | Bottom Counters.Msg
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -53,7 +53,7 @@ update message model =
     Top msg ->
       let 
         (counter', cmd) = 
-          Counter.update msg model.topCounter 
+          Counters.update msg model.topCounter 
       in
         ( { model | topCounter = counter' }
         , Cmd.map Top cmd
@@ -62,7 +62,7 @@ update message model =
     Bottom msg ->
       let 
         (counter', cmd) = 
-          Counter.update msg model.bottomCounter 
+          Counters.update msg model.bottomCounter
       in
         ( { model | bottomCounter = counter' }
         , Cmd.map Bottom cmd
@@ -76,7 +76,7 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ App.map Top (Counter.view model.topCounter)
-    , App.map Bottom (Counter.view model.bottomCounter)
+    [ App.map Top (Counters.view model.topCounter)
+    , App.map Bottom (Counters.view model.bottomCounter)
     , button [ onClick Reset ] [ text "RESET" ]
     ]

--- a/examples/1-counter-pair.elm
+++ b/examples/1-counter-pair.elm
@@ -76,9 +76,7 @@ view : Model -> Html Msg
 view model =
   div
     []
-    [ Counter.view Top model.topCounter
-    , Counter.view Bottom model.bottomCounter
-      -- We avoid Html.App.map because of
-      -- https://github.com/elm-lang/html/issues/16
+    [ App.map Top (Counter.view model.topCounter)
+    , App.map Bottom (Counter.view model.bottomCounter)
     , button [ onClick Reset ] [ text "RESET" ]
     ]

--- a/examples/2-counter-list-part.elm
+++ b/examples/2-counter-list-part.elm
@@ -21,7 +21,7 @@ main =
 
 
 type alias Model =
-  { counter : Indexed Counter.Model 
+  { counters : Counter.Counters
   , first : Int
   , last : Int
   }
@@ -29,7 +29,7 @@ type alias Model =
 
 init : Model
 init =
-  { counter = Dict.empty
+  { counters = Dict.empty
   , first = 0
   , last = -1
   }
@@ -41,7 +41,7 @@ init =
 type Msg
   = Insert
   | Remove
-  | CounterMsg (Parts.Msg Model)
+  | CounterMsg (Counter.Msg, Counter.ID)
 
 
 reset : Int -> Model -> Model
@@ -63,7 +63,7 @@ update msg model =
       )
 
     CounterMsg msg' -> 
-      Parts.update CounterMsg msg' model
+      Counter.pass CounterMsg msg' model
 
 
 -- VIEW

--- a/examples/2-counter-list-part.elm
+++ b/examples/2-counter-list-part.elm
@@ -2,7 +2,7 @@ import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
 
-import Counter
+import Counters exposing (Counters)
 
 
 main : Program Never
@@ -19,7 +19,7 @@ main =
 
 
 type alias Model =
-  { counters : Counter.Counters
+  { counters : Counters
   , first : Int
   , last : Int
   }
@@ -27,7 +27,7 @@ type alias Model =
 
 init : Model
 init =
-  { counters = .empty Counter.all
+  { counters = .empty Counters.all
   , first = 0
   , last = -1
   }
@@ -39,12 +39,12 @@ init =
 type Msg
   = Insert
   | Remove
-  | CounterMsg (Counter.Msg, Counter.ID)
+  | CounterMsg (Counters.Msg, Counters.ID)
 
 
 reset : Int -> Model -> Model
 reset k model = 
-  .reset (Counter.find [k]) model
+  .reset (Counters.find [k]) model
 
 
 update : Msg -> Model -> (Model, Cmd Msg)
@@ -61,7 +61,7 @@ update msg model =
       )
 
     CounterMsg msg' -> 
-      Counter.pass CounterMsg msg' model
+      Counters.pass CounterMsg msg' model
 
 
 -- VIEW
@@ -79,6 +79,6 @@ view model =
     counters =
       [model.first .. model.last]
         |> List.map 
-            (\idx -> Counter.render CounterMsg [idx] model) 
+            (\idx -> Counters.render CounterMsg [idx] model) 
   in
     div [] ([remove, insert] ++ counters)

--- a/examples/2-counter-list-part.elm
+++ b/examples/2-counter-list-part.elm
@@ -1,10 +1,8 @@
 import Html exposing (Html, button, div, text)
 import Html.App as App
 import Html.Events exposing (onClick)
-import Dict 
 
 import Counter
-import Parts exposing (Indexed)
 
 
 main : Program Never
@@ -29,7 +27,7 @@ type alias Model =
 
 init : Model
 init =
-  { counters = Dict.empty
+  { counters = .empty Counter.all
   , first = 0
   , last = -1
   }

--- a/examples/2-counter-list.elm
+++ b/examples/2-counter-list.elm
@@ -93,4 +93,4 @@ view model =
 
 viewCounter : (ID, Counter.Model) -> Html Msg
 viewCounter (id, model) =
-  Counter.view (Modify id) model
+  App.map (Modify id) (Counter.view model)

--- a/examples/2-counter-list.elm
+++ b/examples/2-counter-list.elm
@@ -1,4 +1,4 @@
-import Counter
+import Counters
 import Html exposing (..)
 import Html.App as App
 import Html.Events exposing (..)
@@ -19,7 +19,7 @@ main =
 
 
 type alias Model =
-    { counters : List ( ID, Counter.Model )
+    { counters : List ( ID, Counters.Model )
     , nextID : ID
     }
 
@@ -41,7 +41,7 @@ init =
 type Msg
   = Insert
   | Remove
-  | Modify ID Counter.Msg
+  | Modify ID Counters.Msg
 
 
 update : Msg -> Model -> Model
@@ -50,7 +50,7 @@ update msg model =
     Insert ->
       let
         newCounter =
-          ( model.nextID, Counter.init 0 )
+          ( model.nextID, Counters.init 0 )
 
         newCounters =
           model.counters ++ [ newCounter ]
@@ -64,7 +64,7 @@ update msg model =
       let
         updateCounter (counterID, counterModel) =
           if counterID == id then
-            (counterID, Counter.update counterMsg counterModel |> fst)
+            (counterID, Counters.update counterMsg counterModel |> fst)
 
           else
             (counterID, counterModel)
@@ -91,6 +91,6 @@ view model =
     div [] ([remove, insert] ++ counters)
 
 
-viewCounter : (ID, Counter.Model) -> Html Msg
+viewCounter : (ID, Counters.Model) -> Html Msg
 viewCounter (id, model) =
-  App.map (Modify id) (Counter.view model)
+  App.map (Modify id) (Counters.view model)

--- a/examples/Controls.elm
+++ b/examples/Controls.elm
@@ -1,0 +1,46 @@
+module Controls exposing (..)
+
+import Parts exposing (..)
+import Counters exposing (Counters)
+import Help exposing (Help)
+
+
+
+type Msg
+  = CounterMsg (Counters.Msg, Counters.ID)
+  | HelpMsg Help.Msg
+
+
+update : Msg -> Controls -> (Controls, Cmd Msg)
+update msg model =
+  case msg of
+    CounterMsg msg' -> 
+      Counters.pass CounterMsg msg' model
+
+    HelpMsg msg' -> 
+      Help.pass HelpMsg msg' model
+
+
+
+type alias Controls = 
+  { counters : Counters
+  , help : Help
+  }
+
+type alias Container c = 
+  { c | controls : Controls }
+
+pass 
+   : (Msg -> outerMsg)
+  -> Msg
+  -> Container c
+  -> (Container c, Cmd outerMsg)
+pass =
+  apply1 update instance
+
+instance : Accessors Controls (Container c) 
+instance = 
+  accessors1 .controls (\c i -> { c | controls = i })   
+    { counters = .empty Counters.all 
+    , help = .empty Help.instance
+    }

--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -78,7 +78,7 @@ pass
   -> Container c
   -> (Container c, Cmd outerMsg)
 pass =
-  apply update find 
+  apply update find
 
 render 
    : ((Msg, Index) -> outerMsg) 
@@ -88,6 +88,10 @@ render
 render =
   create view find
 
+all : Collection Model (Container c)
+all = 
+  collection .counters (\x y -> { y | counters = x }) 
+
 find : Index -> Accessors Model (Container c) 
 find = 
-  accessors .counters (\x y -> { y | counters = x }) (init 0)
+  accessors all (init 0)

--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -90,7 +90,8 @@ render =
 
 all : Collection Model (Container c)
 all = 
-  collection .counters (\x y -> { y | counters = x }) 
+  collection .counters (\container collection -> 
+                         { container | counters = collection }) 
 
 find : Index -> Accessors Model (Container c) 
 find = 

--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -1,6 +1,7 @@
 module Counter exposing (Model, init, Msg, update, view, render, find)
 
 import Html exposing (..)
+import Html.App as App
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
 
@@ -40,13 +41,13 @@ update msg model =
 -- VIEW
 
 
-view : (Msg -> m) -> Model -> Html m
-view lift model =
+view : Model -> Html Msg
+view model =
   div 
     []
-    [ button [ onClick (lift Decrement) ] [ text "-" ] 
+    [ button [ onClick Decrement ] [ text "-" ] 
     , div [ countStyle ] [ text (toString model) ]
-    , button [ onClick (lift Increment) ] [ text "+" ] 
+    , button [ onClick Increment ] [ text "+" ] 
     ]
 
 
@@ -75,7 +76,7 @@ set x y =
 
 render : (Parts.Msg (Container c) -> m) -> Parts.Index -> Container c -> Html m
 render = 
-  Parts.create view update .counter set (init 0)
+  Parts.create (\lift -> App.map lift << view) update .counter set (init 0)
 
 
 find : Parts.Index -> Parts.Accessors Model (Container c) 

--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -1,11 +1,10 @@
-module Counter exposing (Model, init, Msg, update, view, render, find)
+module Counter exposing (..)
 
 import Html exposing (..)
-import Html.App as App
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
 
-import Parts exposing (Indexed)
+import Parts exposing (..)
 
 
 -- MODEL
@@ -62,23 +61,33 @@ countStyle =
     ]
 
 
--- PART
+-- Parts
 
+type alias ID =
+  Index
+
+type alias Counters = 
+  Indexed Model
 
 type alias Container c = 
-  { c | counter : Indexed Model }
+  { c | counters : Counters }
 
+pass 
+   : ((Msg, Index) -> outerMsg)
+  -> (Msg, Index)
+  -> Container c
+  -> (Container c, Cmd outerMsg)
+pass =
+  apply update find 
 
-set : Parts.Set (Indexed Model) (Container c) 
-set x y = 
-  { y | counter = x }
+render 
+   : ((Msg, Index) -> outerMsg) 
+  -> Index
+  -> Container c
+  -> Html outerMsg
+render =
+  create view find
 
-
-render : (Parts.Msg (Container c) -> m) -> Parts.Index -> Container c -> Html m
-render = 
-  Parts.create (\lift -> App.map lift << view) update .counter set (init 0)
-
-
-find : Parts.Index -> Parts.Accessors Model (Container c) 
+find : Index -> Accessors Model (Container c) 
 find = 
-  Parts.accessors .counter set (init 0)
+  accessors .counters (\x y -> { y | counters = x }) (init 0)

--- a/examples/Counters.elm
+++ b/examples/Counters.elm
@@ -1,4 +1,4 @@
-module Counter exposing (..)
+module Counters exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)

--- a/examples/Help.elm
+++ b/examples/Help.elm
@@ -1,0 +1,86 @@
+module Help exposing (..)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
+
+import Parts exposing (..)
+
+
+-- MODEL
+
+
+type alias Model 
+  = Bool
+
+
+init : Model
+init =
+  False
+
+
+-- UPDATE
+
+
+type Msg
+  = Toogle
+
+
+update : Msg -> Model -> (Model, Cmd Msg)
+update msg model =
+  case msg of
+    Toogle ->
+      (not model, Cmd.none)
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model =
+  div 
+    []
+    [ div [] [ button [ onClick Toogle ] [ text "Help" ] ]
+    , div [ countStyle ] <| if model then [ text "You need help with this? Seriously?" ] else []
+    ]
+
+
+countStyle : Attribute msg
+countStyle =
+  style
+    [ ("font-size", "16px")
+    , ("font-family", "sans-serif")
+    , ("display", "inline-block")
+    , ("text-align", "center")
+    , ("padding", "10px")
+    , ("background-color", "beige")
+    ]
+
+
+
+-- Parts
+
+type alias Help = 
+  Model
+
+type alias Container c = 
+  { c | help : Help }
+
+pass 
+   : (Msg -> outerMsg)
+  -> Msg
+  -> Container c
+  -> (Container c, Cmd outerMsg)
+pass =
+  apply1 update instance
+
+render 
+   : (Msg -> outerMsg)
+  -> Container c
+  -> Html outerMsg
+render =
+  create1 view instance
+
+instance : Accessors Model (Container c) 
+instance =
+  accessors1 .help (\c i -> { c | help = i })  init

--- a/src/Parts.elm
+++ b/src/Parts.elm
@@ -140,7 +140,7 @@ well, accessors.
 -}
 type alias Accessors model container = 
   { get : container -> model
-  , set : model -> container -> container
+  , set : container -> model -> container
   , map : (model -> model) -> container -> container
   , reset : container -> container
   }
@@ -153,7 +153,7 @@ use this data structure.
 type alias Collection model container =
   { empty : Indexed model
   , get : container -> Indexed model
-  , set : Indexed model -> container -> container
+  , set : container -> Indexed model -> container
   , map : (Index -> model -> model) -> container -> container
   , reset : container -> container
   }
@@ -169,14 +169,14 @@ type alias Collection model container =
 -}
 collection
   : (container -> (Indexed model))
- -> ((Indexed model) -> container -> container)
+ -> (container -> (Indexed model) -> container)
  -> Collection model container
 collection get set =
   { empty = Dict.empty
   , get = get
   , set = set
-  , map = \f c -> get c |> Dict.map f |> flip set c 
-  , reset = set Dict.empty
+  , map = \f c -> get c |> Dict.map f |> set c 
+  , reset = flip set Dict.empty
   }
 
 
@@ -196,15 +196,15 @@ accessors collection model0 idx =
     get container =
       Dict.get idx (collection.get container) |> Maybe.withDefault model0
 
-    set model container = 
-      collection.set (Dict.insert idx model (collection.get container)) container
+    set container model = 
+      collection.set container (Dict.insert idx model (collection.get container))
   in
     { get = get
     , set = set
-    , map = \f c -> get c |> f |> flip set c
+    , map = \f c -> get c |> f |> set c
     , reset = \c -> collection.get c 
                  |> Dict.remove idx 
-                 |> flip collection.set c
+                 |> collection.set c
     }
 
 
@@ -263,7 +263,7 @@ apply' update access wrapper (msg, idx) container =
     item = access idx
   in
     update msg (item.get container)
-      |> map1st (Maybe.map (flip item.set container) >> Maybe.withDefault container)
+      |> map1st (Maybe.map (item.set container) >> Maybe.withDefault container)
       |> map2nd (Cmd.map (\msg' -> wrapper (msg', idx)))
 
 

--- a/src/Parts.elm
+++ b/src/Parts.elm
@@ -1,34 +1,66 @@
 module Parts exposing 
   ( Update, View
-  , Get, Set, embedView, embedUpdate
-  , Index, Indexed, indexed
-  , Msg
-  , pack, update, create, create1, accessors, Accessors
-  , Update', pack', update', create1', embedUpdate'
+  , Index, Indexed, accessors, Accessors
+  , Update', create, apply, apply'
   )
 
 {-| 
 
 Given a TEA component with model type `model` and message type `msg`, we construct
-a variant component which knows how to extract its model from a c model
-`c` and produces generic messages `Msg c`. The consuming component is assumed
-to have message type `obs` (for "observation"). 
+a variant component which knows how to extract its model from a container model
+`container` and produces generic messages `Msg c`.
+
+## Indexed model embeddings
+@docs Index, Indexed
 
 # Elm Architecture types
 @docs Update, View
 
-# Model embeddings 
-@docs Get, Set, embedView, embedUpdate
+# Model embeddings
 @docs accessors, Accessors
 
-## Indexed model embeddings
-@docs Index, Indexed, indexed
+# Construction of viewable compononts
+@docs create
 
-# Message embeddings
-@docs Msg, update, pack
+# Construction of message passing function
+@docs apply, apply'
 
-# Part construction
-@docs create, create1
+# Design
+
+We recommend you define the following for your component:
+(here for the counter component in the examples, do rename all counter-y names.)
+```
+type alias ID =                    -- Optional, this allows your users to avoid
+  Index                            -- the explicit import of Parts
+
+type alias Counters =              -- same here
+  Indexed Model
+
+type alias Container c =           -- A container. Please notice,
+  { c | counters : Counters }      -- that your users' Model needs an unused
+                                   -- field named `counters`.
+pass 
+   : ((Msg, Index) -> outerMsg)    -- A wrapping Msg provided by your users
+  -> (Msg, Index)
+  -> Container c
+  -> (Container c, Cmd outerMsg)
+pass =
+  apply update find
+
+render 
+   : ((Msg, Index) -> outerMsg) 
+  -> Index
+  -> Container c
+  -> Html outerMsg
+render =
+  create view find
+
+find 
+   : Index 
+  -> Accessors Model (Container c) 
+find = 
+  accessors .counters (\x y -> { y | counters = x }) init
+~~~
 
 # Lazyness
 
@@ -49,96 +81,20 @@ In the second line, even if `submodel == model.submodel` and so `model ==
 model'`, we won't have (in Javascript terms) `model === model'`. 
 
 If you need lazy and thus referential equality of no-op updates, use 
-`update'` below instead of the regular `update`, and create your parts with 
-`create1'`, `pack'` etc. These functions all require that your base `update`
+`apply'` below instead of the regular `apply`. This function requires that your base `update`
 function has the type of `Update'`, that is, wraps the resulting model in 
 `Maybe` and explicitly signals a no-op by returning a `Nothing` model. 
 
-@docs Update', update', create1', pack', embedUpdate'
+@docs Update', apply'
 
 -}
 
 import Platform.Cmd exposing (Cmd)
+import Html exposing (Html)
+import Html.App as App
 import Dict exposing (Dict)
 
 
--- TYPES
-
-
-{-| Standard TEA update function type. 
--}
-type alias Update model msg = 
-  msg -> model -> (model, Cmd msg)
-
-
-{-| Standard TEA view function type. 
--}
-type alias View model a = 
-  model -> a
-
-
-{-| TEA update function with explicit no-op. You should have:
-
-    fst (update msg model) == Nothing       -- No change to model
-    fst (update msg model) == Just model'   -- Change to model'
-
--}
-type alias Update' model msg = 
-  msg -> model -> (Maybe model, Cmd msg)
-
-
--- EMBEDDINGS
-
-
-{-| Type of "getter": fetch component model `m` from c model `c`. 
--}
-type alias Get model c =
-  c -> model
-
-
-{-| Type of "setter": update component model `m` in c `c`. 
--}
-type alias Set model c = 
-  model -> c -> c
-
-
-{-| Lift a `view` to one which knows how to retrieve its `model` from 
-a c model `c`. 
--}
-embedView : Get model c -> View model a -> View c a
-embedView get view = 
-  get >> view 
-
-
-{-| Lift an `Update` from operating on `model` to a c model `c`. 
--}
-embedUpdate : 
-    Get model c
- -> Set model c
- -> Update model msg
- -> Update c msg
-embedUpdate get set update = 
-  \msg c -> 
-     update msg (get c) |> map1st (flip set c)
-
-
-{-| Lift an explicit no-op `Update'` from operating on `model` to a c model `c`. 
--}
-embedUpdate' :
-    Get model c
- -> Set model c
- -> Update' model msg
- -> Update' c msg
-embedUpdate' get set update = 
-  \msg c -> 
-    update msg (get c) 
-      |> map1st (Maybe.map (\x -> set x c))
-
-
-
--- INDEXED EMBEDDINGS
-
- 
 {-| Type of indices. An index is a list of `Int` rather than just an `Int` to 
 support nested dynamically constructed elements: Use indices `[0]`, `[1]`, ...
 for statically known top-level components, then use `[0,0]`, `[0,1]`, ...
@@ -154,195 +110,126 @@ type alias Indexed a =
   Dict Index a 
 
 
-{-| Fix a getter and setter for an `Indexed model` to a particular `Index`.
+{-| Standard TEA update function type. 
 -}
-indexed : 
-    Get (Indexed model) c
- -> Set (Indexed model) c
- -> model
- -> (Index -> Get model c, Index -> Set model c)
-indexed get set model0 =  
-  ( \idx c -> Dict.get idx (get c) |> Maybe.withDefault model0
-  , \idx model c -> set (Dict.insert idx model (get c)) c
-  )
-  
-
--- EMBEDDING MESSAGES
+type alias Update model msg = 
+  msg -> model -> (model, Cmd msg)
 
 
-{-| Similar to how embeddings enable collecting models of different type
-in a single model c, we collect messages in a single "master
-message" type. Messages exist exclusively to be dispatched by a corresponding
-`update` function; we can avoid distinguishing between different types of 
-messages by dispatching not the `Msg` itself, but a partially applied update
-function `update msg`. 
-
-It's instructive to compare `Msg` to the type of `update` partially applied to 
-an actual carried message `m`:
-
-    update : m -> c -> (c, Cmd m)
-    (update m) : c -> (c, Cmd m)
+{-| Standard TEA view function type. 
 -}
-type Msg c = 
-  Msg (c -> (Maybe c, Cmd (Msg c)))
+type alias View model a = 
+  model -> Html a
 
 
-{-| Generic update function for `Msg`. 
--}
-update : (Msg c -> m) -> Msg c -> c -> ( c, Cmd m )  
-update fwd (Msg f) c = 
-  f c 
-    |> map1st (Maybe.withDefault c)
-    |> map2nd (Cmd.map fwd)
-  
+{-| TEA update function with explicit no-op. You should have:
 
-{-| Generic explict no-op update function for `Msg`. 
--}
-update' : (Msg c -> m) -> Msg c -> c -> ( Maybe c, Cmd m )  
-update' fwd (Msg f) c = 
-  f c 
-    |> map2nd (Cmd.map fwd)
-  
-
--- PARTS
-
-
-{-| Partially apply an `Update` function to a `msg`, producing a generic Msg.
--}
-pack : (Update c msg) -> msg -> Msg c 
-pack upd msg = 
-  Msg (\c -> 
-    upd msg c 
-      |> map1st Just
-      |> map2nd (Cmd.map (pack upd)))
-
-
-{-| Partially apply an explicit no-op `Update'` function to a `msg`, producing
-a generic Msg.
--}
-pack' : (a -> b -> ( Maybe b, Cmd a )) -> a -> Msg b
-pack' upd msg = 
-  Msg (\c -> 
-    upd msg c 
-      |> map2nd (Cmd.map (pack' upd)))
-
-
-
-{-| From `update` and `view` functions, produce a `view` function which (a) 
-fetches its model from a `c` model, and (b) dispatches generic `Msg`
-messages. 
-
-Its instructive to compare the types of the input `view` and `update` for a 
-typical case. Notice that `create` transforms `model` -> `c` and
-`Html m` -> `Html (Msg c)`. 
-
-  {- Input -}
-  view : (m -> obs) -> model -> List (Attributes m) -> List (Html m) -> Html m
-  update : m -> model -> (model, Cmd m)
-
-  {- Output -}
-  type alias m' = Msg c
-  view : c -> List (Attributes m') -> List (Html m') -> Html m'
-
-Note that the input `view` function is assumed to take a function lifting its
-messages. 
+    fst (update msg model) == Nothing       -- No change to model
+    fst (update msg model) == Just model'   -- Change to model'
 
 -}
-create 
-  : ((m -> obs) -> View model a)
- -> Update model m
- -> Get (Indexed model) c
- -> Set (Indexed model) c
- -> model 
- -> (Msg c -> obs)
- -> Index
- -> View c a
-create view update get0 set0 model0 = 
-  let
-    (get, set) = 
-      indexed get0 set0 model0 
+type alias Update' model msg = 
+  msg -> model -> (Maybe model, Cmd msg)
 
-    embeddedUpdate idx = 
-      embedUpdate (get idx) (set idx) update
-  in
-    \f idx c -> 
-      (view (pack (embeddedUpdate idx) >> f)) (get idx c) 
-
-
-{-| Like `create`, but for components that are assumed to have only one
-instance.
--}
-create1
-  : ((msg -> obs) -> View model a)
- -> Update model msg
- -> Get model c
- -> Set model c
- -> (Msg c -> obs)
- -> View c a
-
-create1 view update get set = 
-  let
-    embeddedUpdate = 
-      embedUpdate get set update
-  in 
-    \f -> 
-      embedView get <| view (pack embeddedUpdate >> f)
-
-
-{-| Like `create1`, but for explicit no-op update functions. 
--}
-create1'
-  : ((msg -> obs) -> View model a)
- -> Update' model msg
- -> Get model c
- -> Set model c
- -> (Msg c -> obs)
- -> View c a
-
-create1' view upd' get set = 
-  let
-    embeddedUpdate = 
-      embedUpdate' get set upd'
-  in 
-    \f -> 
-      embedView get <| view (pack' embeddedUpdate >> f)
 
 
 {-| For components where consumers do care about the model of the 
 component, use the `accessors` function below to generate suitable, 
 well, accessors.
 -}
-type alias Accessors model c = 
-  { get : Get model c
-  , set : Set model c
-  , map : (model -> model) -> c -> c
-  , reset : c -> c
+type alias Accessors model container = 
+  { get : container -> model
+  , set : model -> container -> container
+  , map : (model -> model) -> container -> container
+  , reset : container -> container
   }
 
 
-{-| Generate accessors.
+{-| Generate accessors:
+
+    find = 
+      accessors .myField (\x y -> { y | myField = x }) init
+
 -}
 accessors 
-  : Get (Indexed model) c
- -> Set (Indexed model) c
- -> model 
+  : (container -> (Indexed model))
+ -> ((Indexed model) -> container -> container)
+ -> model
  -> Index
- -> Accessors model c
-
-accessors get0 set0 model0 idx = 
+ -> Accessors model container
+accessors get0 set0 model0 idx =
   let
-    (get, set) =
-      indexed get0 set0 model0 
+    get container =
+      Dict.get idx (get0 container) |> Maybe.withDefault model0
+
+    set model container = 
+      set0 (Dict.insert idx model (get0 container)) container
   in
-    { get = get idx
-    , set = set idx
-    , map = \f c -> (get idx) c |> f |> flip (set idx) c
+    { get = get
+    , set = set
+    , map = \f c -> get c |> f |> flip set c
     , reset = \c -> get0 c |> Dict.remove idx |> (\m -> set0 m c)
     }
 
+{-| Create a viewable component.
 
--- HELPERS
+    For your component:
+    render =
+      create view find
 
+    In your main view:
+    Component.render ComponentMsg [0] model
+-}
+create
+   : View model innerMsg 
+  -> (Index -> Accessors model container)
+  -> ((innerMsg, Index) -> outerMsg)
+  -> Index
+  -> container
+  -> Html outerMsg
+create view access wrapper idx container = 
+  App.map (\msg -> wrapper (msg, idx)) (view ((access idx).get container))
+
+
+{-| Create a function, to pass messages down to your component 
+
+    For your component:
+    pass =
+      apply update find
+
+    In your main update:
+    ComponentMsg msg' -> 
+      Component.pass ComponentMsg msg' model
+-}
+apply
+   : Update model innerMsg
+  -> (Index -> Accessors model container)
+  -> ((innerMsg, Index) -> outerMsg)
+  -> (innerMsg, Index)
+  -> container
+  -> (container, Cmd outerMsg)
+apply update = apply' (\msg -> map1st Just << update msg)
+
+{-| `apply` for components, which `update` function returns the model as a Maybe,
+    depending on whether it changed or not. See the comment on laziness above.
+-}
+apply'
+   : Update' model innerMsg
+  -> (Index -> Accessors model container)
+  -> ((innerMsg, Index) -> outerMsg)
+  -> (innerMsg, Index)
+  -> container
+  -> (container, Cmd outerMsg)
+apply' update access wrapper (msg, idx) container =
+  let 
+    item = access idx
+  in
+    update msg (item.get container)
+      |> map1st (Maybe.map (flip item.set container) >> Maybe.withDefault container)
+      |> map2nd (Cmd.map (\msg' -> wrapper (msg', idx)))
+
+
+-- Helpers
 
 map1st : (a -> c) -> (a,b) -> (c,b)
 map1st f (x,y) = (f x, y)
@@ -350,5 +237,3 @@ map1st f (x,y) = (f x, y)
 
 map2nd : (b -> c) -> (a,b) -> (a,c)
 map2nd f (x,y) = (x, f y)
-
-

--- a/src/Parts.elm
+++ b/src/Parts.elm
@@ -195,11 +195,11 @@ accessors
  -> Accessors model container
 accessors collection model0 idx =
   let
-    get container =
-      Dict.get idx (collection.get container) |> Maybe.withDefault model0
+    get =
+      Maybe.withDefault model0 << Dict.get idx << collection.get
 
-    set container model = 
-      collection.set container (Dict.insert idx model (collection.get container))
+    set container model =
+      collection.set container <| Dict.insert idx model <| collection.get container
   in
     { empty = model0
     , get = get


### PR DESCRIPTION
This PR is a major refactoring of Parts.elm
It replaces all the functions with these nine:
- collection
  - create a Collection with encapsulates all Dict logic.
- accessors
  - create Accessors, like before
- create
  -  Construction of viewable compononts
  - render = create view find
- apply
  - Construction of message passing function
  - Unlike before, the components now have to specify a pass function
  - pass = apply update find
  - CounterMsg msg' -> Counter.pass CounterMsg msg' model
- apply'
  - `apply` for components, which `update` function returns the model as a Maybe,
    depending on whether it changed or not.
- accessors1, create1, apply1, apply1'
  - Like above, but for components with only one instance.

This slightly increases the code size of the components,
but more importantly it completely hides Dict from everybody and Parts from the component user.

Issue: Unfortunatly collections are way less useful than they should be due to [#520](https://github.com/elm-lang/elm-compiler/issues/520) 

EDIT: Also it has elm-lang/html as a dependency, which hopefully shouldn't be a issue as this library is so view centric.
