### PR TITLE
Allow for user defined comparable Indexes for Parts

### DIFF
--- a/examples/0-counter-part.elm
+++ b/examples/0-counter-part.elm
@@ -4,7 +4,7 @@ import Html.Events exposing (onClick)
 import Dict 
 
 import Counter
-import Parts exposing (Indexed)
+import Parts
 
 
 main : Program Never
@@ -21,7 +21,7 @@ main =
 
 
 type alias Model =
-  { counter : Indexed Counter.Model 
+  { counter : Counter.Indexed Counter.Model
   }
 
 

--- a/examples/1-counter-pair-part.elm
+++ b/examples/1-counter-pair-part.elm
@@ -4,7 +4,7 @@ import Html.Events exposing (onClick)
 import Dict 
 
 import Counter
-import Parts exposing (Indexed)
+import Parts
 
 
 main : Program Never
@@ -21,7 +21,7 @@ main =
 
 
 type alias Model =
-  { counter : Indexed Counter.Model 
+  { counter : Counter.Indexed Counter.Model
   }
 
 

--- a/examples/2-counter-list-part.elm
+++ b/examples/2-counter-list-part.elm
@@ -4,7 +4,7 @@ import Html.Events exposing (onClick)
 import Dict 
 
 import Counter
-import Parts exposing (Indexed)
+import Parts
 
 
 main : Program Never
@@ -21,7 +21,7 @@ main =
 
 
 type alias Model =
-  { counter : Indexed Counter.Model 
+  { counter : Counter.Indexed Counter.Model
   , first : Int
   , last : Int
   }

--- a/examples/Counter.elm
+++ b/examples/Counter.elm
@@ -1,10 +1,10 @@
-module Counter exposing (Model, init, Msg, update, view, render, find)
+module Counter exposing (Model, init, Msg, update, view, render, find, Index, Indexed)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
 
-import Parts exposing (Indexed)
+import Parts
 
 
 -- MODEL
@@ -62,7 +62,11 @@ countStyle =
 
 
 -- PART
+type alias Indexed m =
+  Parts.Indexed (List Int) m
 
+type alias Index =
+  Parts.Index (List Int)
 
 type alias Container c = 
   { c | counter : Indexed Model }
@@ -73,11 +77,11 @@ set x y =
   { y | counter = x }
 
 
-render : (Parts.Msg (Container c) m -> m) -> Parts.Index -> Container c -> Html m
+render : (Parts.Msg (Container c) m -> m) -> Index -> Container c -> Html m
 render = 
   Parts.create view (Parts.generalize update) .counter set (init 0)
 
 
-find : Parts.Index -> Parts.Accessors Model (Container c) 
+find : Index -> Parts.Accessors Model (Container c)
 find = 
   Parts.accessors .counter set (init 0)

--- a/src/Parts.elm
+++ b/src/Parts.elm
@@ -121,28 +121,30 @@ embedUpdate get set update =
 -- INDEXED EMBEDDINGS
 
  
-{-| Type of indices. An index is a list of `Int` rather than just an `Int` to 
+{-| Type of indices. An index has to be `comparable`
+
+For example:
+An index can be a list of `Int` rather than just an `Int` to
 support nested dynamically constructed elements: Use indices `[0]`, `[1]`, ...
 for statically known top-level components, then use `[0,0]`, `[0,1]`, ...
-for a dynamically generated list of components. 
+for a dynamically generated list of components.
 -}
-type alias Index 
-  = List Int
- 
+type alias Index b = b
+
 
 {-| Indexed families of things.
 -}
-type alias Indexed a = 
-  Dict Index a 
+type alias Indexed c a
+  = Dict (Index c) a
 
 
-{-| Fix a getter and setter for an `Indexed model` to a particular `Index`.
+{-| Fix a getter and setter for an `Indexed comparable model` to a particular `Index comparable`.
 -}
 indexed : 
-    Get (Indexed model) c
- -> Set (Indexed model) c
+    Get (Indexed comparable model) c
+ -> Set (Indexed comparable model) c
  -> model
- -> (Index -> Get model c, Index -> Set model c)
+ -> (Index comparable -> Get model c, Index comparable -> Set model c)
 indexed get set model0 =  
   ( \idx c -> Dict.get idx (get c) |> Maybe.withDefault model0
   , \idx model c -> set (Dict.insert idx model (get c)) c
@@ -201,11 +203,11 @@ partial fwd upd msg =
 -}
 pack
   : Update model msg obs
-  -> Get (Indexed model) c
-  -> Set (Indexed model) c
+  -> Get (Indexed comparable model) c
+  -> Set (Indexed comparable model) c
   -> model
   -> (Msg c obs -> obs)
-  -> Index
+  -> Index comparable
   -> msg
   -> obs
 pack update get0 set0 model0 fwd = 
@@ -244,7 +246,7 @@ typical case. Notice that `create` transforms `model` -> `c` and
   update : (m -> obs) -> model -> (Maybe model, Cmd obs)
 
   {- Output -}
-  view : Index -> c -> List (Attributes obs) -> List (Html obs) -> Html obs
+  view : Index comparable -> c -> List (Attributes obs) -> List (Html obs) -> Html obs
 
 Note that the input `view` function is assumed to take a function lifting its
 messages. 
@@ -252,11 +254,11 @@ messages.
 create 
   : ((msg -> obs) -> View model a)
  -> Update model msg obs
- -> Get (Indexed model) c
- -> Set (Indexed model) c
+ -> Get (Indexed comparable model) c
+ -> Set (Indexed comparable model) c
  -> model 
  -> (Msg c obs -> obs)
- -> Index
+ -> Index comparable
  -> View c a
 create view update get0 set0 model0 fwd = 
   let
@@ -304,10 +306,10 @@ type alias Accessors model c =
 {-| Generate accessors.
 -}
 accessors 
-  : Get (Indexed model) c
- -> Set (Indexed model) c
+  : Get (Indexed comparable model) c
+ -> Set (Indexed comparable model) c
  -> model 
- -> Index
+ -> Index comparable
  -> Accessors model c
 
 accessors get0 set0 model0 idx = 


### PR DESCRIPTION
This is based on https://github.com/debois/elm-mdl/issues/196

This requires the user of the library to write little extra boilerplate if they want to use it the same way but other than that the basic functionality should be unchanged.

For example to have the current indexed lists you can just add the following type aliases somewhere where you can then use them instead of `Parts.Index(ed)`

``` elm
type alias Indexed m =
  Parts.Indexed (List Int) m

type alias Index =
  Parts.Index (List Int)
```

To use a string for example the following should work 

``` elm
type alias Indexed m =
  Parts.Indexed String m

type alias Index =
  Parts.Index String
```
