### PR TITLE
Elm 0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ index.html
 todo 
 .*.sw?
 docs.json
+elm-stuff

--- a/examples/0-counter-part.elm
+++ b/examples/0-counter-part.elm
@@ -1,16 +1,15 @@
 module Main exposing (..)
 
 import Html exposing (Html, button, div, text)
-import Html.App as App
 import Html.Events exposing (onClick)
 import Dict
 import Counter
 import Parts
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
-  App.program
+  Html.program
     { init = init
     , subscriptions = always Sub.none
     , update = update

--- a/examples/0-counter.elm
+++ b/examples/0-counter.elm
@@ -2,13 +2,12 @@ module Main exposing (..)
 
 import Counter
 import Html exposing (Html, button, div, text)
-import Html.App as App
 import Html.Events exposing (onClick)
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
-  App.program
+  Html.program
     { init = init 0
     , update = update
     , view = view

--- a/examples/1-counter-pair-part.elm
+++ b/examples/1-counter-pair-part.elm
@@ -8,9 +8,9 @@ import Counter
 import Parts
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
-  App.program
+  Html.program
     { init = init
     , subscriptions = always Sub.none
     , update = update

--- a/examples/1-counter-pair.elm
+++ b/examples/1-counter-pair.elm
@@ -2,13 +2,12 @@ module Main exposing (..)
 
 import Counter
 import Html exposing (Html, button, div, text)
-import Html.App as App
 import Html.Events exposing (onClick)
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
-  App.program
+  Html.program
     { init = init 0 0
     , update = update
     , view = view

--- a/examples/2-counter-list-part.elm
+++ b/examples/2-counter-list-part.elm
@@ -1,16 +1,15 @@
 module Main exposing (..)
 
 import Html exposing (Html, button, div, text)
-import Html.App as App
 import Html.Events exposing (onClick)
 import Dict
 import Counter
 import Parts
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
-  App.program
+  Html.program
     { init = ( init, Cmd.none )
     , subscriptions = always Sub.none
     , update = update

--- a/examples/2-counter-list.elm
+++ b/examples/2-counter-list.elm
@@ -2,13 +2,12 @@ module Main exposing (..)
 
 import Counter
 import Html exposing (..)
-import Html.App as App
 import Html.Events exposing (..)
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
-  App.beginnerProgram
+  Html.beginnerProgram
     { model = init
     , update = update
     , view = view

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -9,11 +9,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "elm-lang/svg": "1.0.0 <= v < 2.0.0",
-        "elm-lang/websocket": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Parts.elm
+++ b/src/Parts.elm
@@ -131,7 +131,7 @@ embedUpdate :
 embedUpdate get set update =
     \f msg c ->
         update f msg (get c)
-            |> map1st (Maybe.map <| flip set c)
+            |> Tuple.mapFirst (Maybe.map <| flip set c)
 
 
 
@@ -194,7 +194,7 @@ type Msg c obs
 -}
 update : Msg c obs -> c -> ( c, Cmd obs )
 update (Msg f) c =
-    f c |> map1st (Maybe.withDefault c)
+    f c |> Tuple.mapFirst (Maybe.withDefault c)
 
 
 {-| Generic update function for `Msg`, explicit no-op
@@ -349,19 +349,8 @@ generalize :
     -> Update model msg obs
 generalize upd f m c =
     upd m c
-        |> map1st Just
-        |> map2nd (Cmd.map f)
+        |> Tuple.mapFirst Just
+        |> Tuple.mapSecond (Cmd.map f)
 
 
 
--- HELPERS
-
-
-map1st : (a -> c) -> ( a, b ) -> ( c, b )
-map1st f ( x, y ) =
-    ( f x, y )
-
-
-map2nd : (b -> c) -> ( a, b ) -> ( a, c )
-map2nd f ( x, y ) =
-    ( x, f y )


### PR DESCRIPTION
- Remove map1st and map2nd in favour of Tuple.mapFirst and Tuple.mapSecond
- Updated examples to work with elm 0.18